### PR TITLE
Enhancing the acceptance tests

### DIFF
--- a/features/step_definitions/send-to-backpack-steps.js
+++ b/features/step_definitions/send-to-backpack-steps.js
@@ -1,4 +1,5 @@
 var fiberize = require('../../test/lib/fiber-cucumber');
+var should = require('should');
 
 module.exports = fiberize(function() {
   this.Given(/^I am logged into my Backpack as (.+)$/, function(email) {
@@ -26,8 +27,13 @@ module.exports = fiberize(function() {
 
   this.When(/^(?:I|they) (start sending|send) .* to my Backpack.*$/, function(sendType) {
     this.sendGroup = this.site.sendBadgesTo(this.backpack);
-    if (sendType == "send")
+    if (sendType == "send") {
+      this.sendGroup.forEach(function(request) {
+        should.equal(request.result, null);
+        request.canBeAccepted.should.equal(true); 
+      });
       this.sendGroup.acceptAll();
+    }
   });
 
   this.When(/^I reject it$/, function() {
@@ -35,11 +41,12 @@ module.exports = fiberize(function() {
   });
 
   this.Then(/^I should see (?:my|the) badges? in my Backpack$/, function() {
-    this.backpack.should.includeEach(this.site.issuedBadges);
+    this.sendGroup[0].result.should.equal("accepted");
+    this.backpack.should.includeBadges(this.site.issuedBadges);
   });
 
   this.Then(/^I should not see it in my Backpack$/, function() {
-    this.backpack.should.not.includeEach(this.site.issuedBadges);
+    this.backpack.should.not.includeBadges(this.site.issuedBadges);
   });
 
   this.Then(/^I should see a notice that I already have that badge$/, function() {

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -1,92 +1,97 @@
 var should = require('should');
-
+var badgehost = require('badgehost');
+var validator = require('openbadges-validator');
 var fiberize = require('../../test/lib/fiber-cucumber');
+var Future = require('fibers/future');
+var SendToBackpackRequest = require('../../').SendToBackpackRequest;
+var SendToBackpackRequestGroup = SendToBackpackRequest.Group;
+
+var badgehostApp;
 
 var DEFAULT_EMAIL = "me@example.org";
 
-function Backpack() {
+var FakeBackpack = function(owner) {
   var self = [];
 
-  self.owner = DEFAULT_EMAIL;
+  self.owner = owner;
 
-  return self;
-}
-
-function Badge(options) {
-  var self = this;
-
-  self.recipient = options.recipient;
-
-  return self;
-}
-
-function SendToBackpackRequest(backpack, badge) {
-  var self = {result: null};
-
-  self.accept = function() {
-    should.equal(self.result, null);
-    backpack.push(badge);
-    self.result = "accepted";
+  self.has = function(guid, cb) {
+    return cb(null, self.indexOf(guid) != -1)
   };
 
-  self.reject = function() {
-    should.equal(self.result, null);
-    self.result = "rejected";
+  self.indexOfBadgeWithUrl = function(url) {
+    var getAssertionGUID = Future.wrap(validator.getAssertionGUID);
+    var guid = getAssertionGUID(url).wait();
+    return Array.prototype.indexOf.call(self, guid);
   };
 
-  if (backpack.owner != badge.recipient)
-    self.result = "recipient_mismatch";
-
-  if (backpack.indexOf(badge) !== -1)
-    self.result = "exists";
-
-  return self;
-}
-
-function SendToBackpackRequestGroup(badges, backpack) {
-  var self = new Array();
-
-  badges.forEach(function(badge) {
-    self.push(SendToBackpackRequest(backpack, badge));
-  });
-
-  self.acceptAll = function() {
-    self.forEach(function(request) { request.accept(); });
-  };
-
-  self.rejectAll = function() {
-     self.forEach(function(request) { request.reject(); });
+  self.receive = function(info, cb) {
+    info.guid.should.be.a('string');
+    self.indexOf(info.guid).should.eql(-1);
+    self.push(info.guid);
+    cb(null);
   };
 
   return self;
-}
+};
+
+var badgeFor = function(recipient, uid) {
+  return badgehostApp.url('demo.json', {
+    set: {
+      uid: uid || 'uid-1',
+      recipient: {
+        type: "email",
+        hashed: false,
+        identity: recipient
+      }
+    }
+  })
+};
 
 function IssuerSite() {
   var self = this;
-  
+ 
+  var uid_n = 1;
+
   self.loggedInUser = DEFAULT_EMAIL;
-  self.issuedBadges = [];
+  self.issuedBadges = []; // NOTE: issued, not sent
 
   self.issueBadge = function() {
-    self.issuedBadges.push(new Badge({recipient: self.loggedInUser}));
+    self.issuedBadges.push(badgeFor(self.loggedInUser, 'uid-' + uid_n++));
   };
 
   self.sendBadgesTo = function(backpack) {
-    return SendToBackpackRequestGroup(self.issuedBadges, backpack);
+    // Thimble-style always send all
+    return SendToBackpackRequestGroup(backpack, self.issuedBadges);
   };
 
   return self;
 }
 
-should.Assertion.prototype.includeEach = function(array) {
+should.Assertion.prototype.includeBadges = function(array) {
+  array.length.should.be.above(0);
   array.forEach(function(item) {
-    this.include(item);
+    this.assert(
+      ~this.obj.indexOfBadgeWithUrl(item), 
+      function(){ return 'expected backpack to include badge with url ' + item },
+      function(){ return 'expected backpack to not include badge with url ' + item }
+    );
   }, this);
 };
 
 module.exports = fiberize(function() {
   this.Before(function(){
     this.site = new IssuerSite();
-    this.backpack = new Backpack();
+    this.backpack = new FakeBackpack(DEFAULT_EMAIL);
+    badgehostApp = badgehost.app.build();
+    var doneListening = new Future();
+    badgehostApp.listen(function() {
+      doneListening.return(this);
+    });
+    badgehostApp.server = doneListening.wait();
+  });
+
+  this.After(function(){
+    badgehostApp.server.close();
   });
 });

--- a/features/support/env.js
+++ b/features/support/env.js
@@ -20,7 +20,7 @@ function Badge(options) {
   return self;
 }
 
-function SendToBackpackRequest(badge, backpack) {
+function SendToBackpackRequest(backpack, badge) {
   var self = {result: null};
 
   self.accept = function() {
@@ -47,7 +47,7 @@ function SendToBackpackRequestGroup(badges, backpack) {
   var self = new Array();
 
   badges.forEach(function(badge) {
-    self.push(SendToBackpackRequest(badge, backpack));
+    self.push(SendToBackpackRequest(backpack, badge));
   });
 
   self.acceptAll = function() {


### PR DESCRIPTION
With this PR the acceptance tests use the new `SendToBackpackRequest` and `SendToBackpackRequest.Group` objects, which also involved upgrading the notion of badges to URLs backed by actual assertions, and enhancing the FakeBackpack class similarly to the unit tests.
